### PR TITLE
fix: enable auto-close for release pipeline JIRA issues

### DIFF
--- a/.github/workflows/konflux-compliance-scanner.yml
+++ b/.github/workflows/konflux-compliance-scanner.yml
@@ -795,6 +795,10 @@ jobs:
 
           if [[ -f "$RELEASE_CSV" ]]; then
             source ./create-compliance-jira-issues.sh
+            # Override AUTO_CLOSE since sourcing the script resets it to false.
+            # The main() path uses --auto-close flag, but direct function calls
+            # need the variable set explicitly.
+            AUTO_CLOSE=true
             create_release_jira_issues "$RELEASE_CSV" 2>&1 | tee "${{ github.workspace }}/logs/${{ matrix.application }}-release-jira.log"
           else
             echo "No release status CSV found, skipping"


### PR DESCRIPTION
## Summary

- **Bug**: Release pipeline JIRA issues (e.g. ACM-32008, ACM-32009, etc.) were never auto-closed even when the latest Konflux Snapshot was fully healthy
- **Root cause**: The "Create release JIRA issues" step calls `create_release_jira_issues()` directly via `source`, bypassing `main()` which parses `--auto-close`. The script's global default `AUTO_CLOSE=false` overrides the workflow env var, so the auto-close code path was never reached
- **Fix**: Set `AUTO_CLOSE=true` explicitly before calling the function

## Impact

~13 release failure JIRA issues (ACM-32008, ACM-32009, ACM-32015, ACM-32017, ACM-32018, ACM-32019, ACM-32022, ACM-32023, ACM-32028, ACM-32034, ACM-32035, ACM-32048, ACM-32196) have been stuck open for >7 days despite many having their latest Snapshots fully healthy. After this fix, they will be auto-closed on the next hourly scan.

## Evidence

From the workflow run [#24076370200](https://github.com/stolostron/acm-infra/actions/runs/24076370200) logs:
```
Latest Snapshot for acm-216 is fully healthy (2/2 succeeded)
```
But no auto-close was attempted. Verified via Konflux that acm-214, acm-215, acm-216, mce-26, mce-27, mce-28, mce-29 all have latest Snapshots with 100% success.

## Test plan

- [ ] Merge this PR
- [ ] Wait for next hourly compliance scan to run
- [ ] Verify that release JIRA issues for healthy versions (e.g. ACM-32008 for acm-216) are auto-closed
- [ ] Verify that release JIRA issues for still-failing versions (e.g. mce-210, mce-217) remain open

🤖 Generated with [Claude Code](https://claude.com/claude-code)