### PR TITLE
Added GitLab processes between steps

### DIFF
--- a/konflux/release-process/AGENTS.md
+++ b/konflux/release-process/AGENTS.md
@@ -77,17 +77,26 @@ just check-release <BUNDLE_RELEASE_NAME>
 # 5. Update catalog request for prod (creates PR to catalog repo, rc not needed for prod)
 just generate-snapshot catalog prod acm 2.12.42 --dry_run false
 
-# 6. Create catalog release files for STAGE NOT PROD
+# 6. Monitor catalog PR merge and wait for pipeline builds
+just check-pr catalog <PR_NUMBER>
+just check-commit <MERGE_COMMIT_SHA>
+
+# ⚠️  MANDATORY PAUSE: Send the catalog snapshot to QE in the release thread and
+#    WAIT for QE testing to complete before continuing! Do NOT proceed until QE signs off.
+# Get the catalog snapshot from the merged PR commit:
+just get-catalog-snapshot prod acm <MERGE_COMMIT_SHA>
+
+# 7. Create catalog release files for STAGE NOT PROD
 # Note: RC is 1-prod to generate catalog files. Dry run TRUE is fine.
 just release catalog stage acm 2.12.42 --rc 1-prod --snapshot <CATALOG_SNAPSHOT>
 
-# 7. Promote catalog to prod (from stage rc1-prod)
+# 8. Promote catalog to prod (from stage rc1-prod)
 just release catalog prod acm 2.12.42 --rc 1-prod --dry_run false
 
-# 8. Monitor catalog releases
+# 9. Monitor catalog releases
 just check-catalog-releases prod acm 2.12.42
 
-# 9. Create GitLab MR for release files
+# 10. Create GitLab MR for release files
 just create-mr acm 2.12.42
 ```
 

--- a/konflux/release-process/AGENTS.md
+++ b/konflux/release-process/AGENTS.md
@@ -148,6 +148,12 @@ All recipes for a given app+version share a single GitLab branch: `release-{app}
 
 Files are committed and pushed incrementally after each `stage-release` and `prod-release` step, so progress is backed up to GitLab piecewise. At the end of the workflow, `create-mr` opens a GitLab MR to merge the branch into main.
 
+## Multi-App Ordering (ACM + MCE)
+
+When releasing both ACM and MCE together:
+- **Payload and bundle steps** may be run concurrently for ACM and MCE (no dependency between them).
+- **Catalog step**: MCE catalog must be fully built and released **before** starting the ACM catalog. This applies to all catalog sub-steps (`generate-snapshot catalog`, PR merge, `release catalog`). Complete the entire MCE catalog flow first, then proceed with ACM.
+
 ## Common "Gotchas"
 - This justfile is using `just 1.46.0`, which has new ways of handeling recipe arguments. No longer do you specify arguments with arg=value, you must instead add the [arg()] descriptor and then pass the argument with `--arg value`. Global variables are still specified with `arg=value` *before* the recipe call (example: `just debug=true <recipe> --<arg> <value>`)
 - **All apply operations default to dry-run** - Must pass `--dry_run false` to apply live

--- a/konflux/release-process/AGENTS.md
+++ b/konflux/release-process/AGENTS.md
@@ -45,13 +45,16 @@ just generate-snapshot catalog stage acm 2.12.42 --rc 1 --dry_run false
 just check-pr catalog <PR_NUMBER>
 just check-commit <MERGE_COMMIT_SHA>
 
-# 10. Create catalog release (OCP versions auto-detected)
+# 10. Get catalog snapshot from merged PR
+just get-catalog-snapshot stage acm <MERGE_COMMIT_SHA>
+
+# 11. Create catalog release (OCP versions auto-detected)
 just release catalog stage acm 2.12.42 --snapshot <CATALOG_SNAPSHOT> --rc 1 --dry_run false
 
-# 11. Monitor catalog releases (OCP versions auto-detected)
+# 12. Monitor catalog releases (OCP versions auto-detected)
 just check-catalog-releases stage acm 2.12.42 --rc 1
 
-# 12. Create GitLab MR for release files
+# 13. Create GitLab MR for release files
 just create-mr acm 2.12.42
 ```
 

--- a/konflux/release-process/AGENTS.md
+++ b/konflux/release-process/AGENTS.md
@@ -50,6 +50,9 @@ just release catalog stage acm 2.12.42 --snapshot <CATALOG_SNAPSHOT> --rc 1 --dr
 
 # 11. Monitor catalog releases (OCP versions auto-detected)
 just check-catalog-releases stage acm 2.12.42 --rc 1
+
+# 12. Create GitLab MR for release files
+just create-mr acm 2.12.42
 ```
 
 ## Prod Release Workflow
@@ -83,6 +86,9 @@ just release catalog prod acm 2.12.42 --rc 1-prod --dry_run false
 
 # 8. Monitor catalog releases
 just check-catalog-releases prod acm 2.12.42
+
+# 9. Create GitLab MR for release files
+just create-mr acm 2.12.42
 ```
 
 ## Key Command Syntax
@@ -122,9 +128,16 @@ just get-snapshot-from-pr <app> <pr-number>
 just verify-catalog-snapshot <type> <app> <version> <snapshot>
 just get-catalog-snapshot <type> <app> <commit-sha>
 just get-advisory <release-name>
+just create-mr <app> <version>
 just clone-release-mgmt <branch-name>
 just cleanup
 ```
+
+## Branch Model
+
+All recipes for a given app+version share a single GitLab branch: `release-{app}-{version}` (e.g., `release-acm-2.12.42`). Stage RCs, prod promotions — everything goes on the same branch.
+
+Files are committed and pushed incrementally after each `stage-release` and `prod-release` step, so progress is backed up to GitLab piecewise. At the end of the workflow, `create-mr` opens a GitLab MR to merge the branch into main.
 
 ## Common "Gotchas"
 - This justfile is using `just 1.46.0`, which has new ways of handeling recipe arguments. No longer do you specify arguments with arg=value, you must instead add the [arg()] descriptor and then pass the argument with `--arg value`. Global variables are still specified with `arg=value` *before* the recipe call (example: `just debug=true <recipe> --<arg> <value>`)

--- a/konflux/release-process/README.md
+++ b/konflux/release-process/README.md
@@ -50,10 +50,13 @@ just generate-snapshot catalog stage acm 2.12.42 --rc 1 --dry_run false
 just check-pr catalog <PR_NUMBER>
 just check-commit <MERGE_COMMIT_SHA>
 
-# 10. Create catalog release (OCP versions auto-detected)
-just release catalog stage acm 2.12.42 --snapshot snapshot-def --rc 1 --dry_run false
+# 10. Get catalog snapshot from merged PR
+just get-catalog-snapshot stage acm <MERGE_COMMIT_SHA>
 
-# 11. Monitor catalog releases (OCP versions auto-detected)
+# 11. Create catalog release (OCP versions auto-detected)
+just release catalog stage acm 2.12.42 --snapshot <CATALOG_SNAPSHOT> --rc 1 --dry_run false
+
+# 12. Monitor catalog releases (OCP versions auto-detected)
 just check-catalog-releases stage acm 2.12.42 --rc 1
 ```
 

--- a/konflux/release-process/README.md
+++ b/konflux/release-process/README.md
@@ -382,6 +382,12 @@ acm-release-management/
 
 ## Important Notes
 
+### Multi-App Ordering (ACM + MCE)
+
+When releasing both ACM and MCE together:
+- **Payload and bundle steps** may be run concurrently for ACM and MCE (no dependency between them).
+- **Catalog step**: MCE catalog must be fully built and released **before** starting the ACM catalog. This applies to all catalog sub-steps (`generate-snapshot catalog`, PR merge, `release catalog`). Complete the entire MCE catalog flow first, then proceed with ACM.
+
 ### Y-stream vs Z-stream Releases
 
 - **Y-stream releases** (X.Y.0): Skip bug/CVE queries, always RHEA type

--- a/konflux/release-process/README.md
+++ b/konflux/release-process/README.md
@@ -58,6 +58,9 @@ just release catalog stage acm 2.12.42 --snapshot <CATALOG_SNAPSHOT> --rc 1 --dr
 
 # 12. Monitor catalog releases (OCP versions auto-detected)
 just check-catalog-releases stage acm 2.12.42 --rc 1
+
+# 13. Create GitLab MR for release files
+just create-mr acm 2.12.42
 ```
 
 #### Prod Release Workflow
@@ -80,17 +83,27 @@ just check-release <BUNDLE_RELEASE_NAME>
 # 5. Update catalog request for prod (creates PR to catalog repo)
 just generate-snapshot catalog prod acm 2.12.42 --dry_run false
 
-# 6. Create catalog release files for STAGE NOT PROD (OCP versions auto-detected)
-# Note that the RC has been chosen as 1-prod. This is to generate and save
-# the new catalog release files to promote to PROD. Dry run TRUE (default)
-# is fine, these do not need to be released to stage first
+# 6. Monitor catalog PR merge and wait for pipeline builds
+just check-pr catalog <PR_NUMBER>
+just check-commit <MERGE_COMMIT_SHA>
+
+# ⚠️  MANDATORY PAUSE: Send the catalog snapshot to QE in the release thread and
+#    WAIT for QE testing to complete before continuing! Do NOT proceed until QE signs off.
+# Get the catalog snapshot from the merged PR commit:
+just get-catalog-snapshot prod acm <MERGE_COMMIT_SHA>
+
+# 7. Create catalog release files for STAGE NOT PROD
+# Note: RC is 1-prod to generate catalog files. Dry run TRUE is fine.
 just release catalog stage acm 2.12.42 --rc 1-prod --snapshot <CATALOG_SNAPSHOT>
 
-# 7. Promote catalog to prod (from stage rc1-prod files)
+# 8. Promote catalog to prod (from stage rc1-prod)
 just release catalog prod acm 2.12.42 --rc 1-prod --dry_run false
 
-# 8. Monitor catalog releases (OCP versions auto-detected)
+# 9. Monitor catalog releases
 just check-catalog-releases prod acm 2.12.42
+
+# 10. Create GitLab MR for release files
+just create-mr acm 2.12.42
 ```
 
 ## Main Workflows

--- a/konflux/release-process/justfile
+++ b/konflux/release-process/justfile
@@ -1245,7 +1245,7 @@ create-mr app version:
     echo "$push_output"
 
     # Extract and display MR URL
-    mr_url=$(echo "$push_output" | grep -oP 'https://[^ ]+merge_requests/\d+' | head -1)
+    mr_url=$(echo "$push_output" | grep -oE 'https://[^ ]+merge_requests/[0-9]+' | head -1)
     if [ -n "$mr_url" ]; then
         echo ""
         echo "✅ Merge request created: $mr_url"

--- a/konflux/release-process/justfile
+++ b/konflux/release-process/justfile
@@ -70,6 +70,7 @@ help:
     @echo "  verify-catalog-snapshot <type> <app> <version> <snapshot>"
     @echo "  get-catalog-snapshot <type> <app> <commit-sha>"
     @echo "  get-advisory <release-name>"
+    @echo "  create-mr <app> <version>   - Create GitLab MR for release files"
     @echo "  clone-release-mgmt <branch-name>"
     @echo "  cleanup - Remove cloned repos"
     @echo ""
@@ -111,6 +112,9 @@ help:
     @echo "  # 11. Monitor catalog releases"
     @echo "  just check-catalog-releases stage acm 2.12.42 --rc 1"
     @echo ""
+    @echo "  # 12. Create GitLab MR for release files (after all steps done)"
+    @echo "  just create-mr acm 2.12.42"
+    @echo ""
     @echo "Prod Release Workflow:"
     @echo "  Note: --rc specifies which stage RC to promote from (e.g. --rc 1 promotes from stage rc1)"
     @echo ""
@@ -140,6 +144,14 @@ help:
     @echo ""
     @echo "  # 8. Monitor catalog releases"
     @echo "  just check-catalog-releases prod acm 2.12.42"
+    @echo ""
+    @echo "  # 9. Create GitLab MR for release files (after all steps done)"
+    @echo "  just create-mr acm 2.12.42"
+    @echo ""
+    @echo "NOTES:"
+    @echo "  All recipes share a single branch: release-{app}-{version}"
+    @echo "  Files are pushed incrementally after each step for backup"
+    @echo "  create-mr opens a GitLab MR at the end of the workflow"
     @echo ""
     @echo "VARIABLES:"
     @echo "  debug=true        Enable debug output"
@@ -1173,6 +1185,69 @@ cleanup:
         fi
     done
 
+# Create a GitLab merge request for the release management branch
+create-mr app version:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    repo_dir="acm-release-management"
+    branch_name="release-{{app}}-{{version}}"
+    gitlab_host="gitlab.cee.redhat.com"
+    upstream="acm/acm-release-management"
+    app_upper=$(echo "{{app}}" | tr '[:lower:]' '[:upper:]')
+
+    if [ ! -d "$repo_dir" ]; then
+        echo "❌ Release management repo not found" >&2
+        echo "   Run a release workflow first to populate it" >&2
+        exit 1
+    fi
+
+    cd "$repo_dir"
+
+    # Verify we're on the expected branch
+    current_branch=$(git branch --show-current)
+    if [ "$current_branch" != "$branch_name" ]; then
+        echo "❌ Expected branch '$branch_name' but on '$current_branch'" >&2
+        exit 1
+    fi
+
+    # Check there are commits ahead of main
+    commits_ahead=$(git rev-list --count origin/main..HEAD 2>/dev/null || echo "0")
+    if [ "$commits_ahead" = "0" ]; then
+        echo "❌ No commits ahead of main — nothing to merge" >&2
+        exit 1
+    fi
+
+    echo "📬 Creating merge request on GitLab..."
+    echo "   Branch: $branch_name ($commits_ahead commits ahead of main)"
+    echo "   Target: main"
+    echo ""
+
+    # Show commit log
+    echo "Commits:"
+    git log --oneline origin/main..HEAD
+    echo ""
+
+    # Build MR URL for push-and-create flow
+    mr_title="${app_upper} {{version}} release files"
+    encoded_title=$(python3 -c "import urllib.parse; print(urllib.parse.quote('${mr_title}'))")
+
+    # Push latest (should be up-to-date from incremental pushes, but ensure)
+    git push origin HEAD
+
+    # Open MR creation URL
+    mr_url="https://${gitlab_host}/${upstream}/-/merge_requests/new?merge_request%5Bsource_branch%5D=${branch_name}&merge_request%5Btarget_branch%5D=main&merge_request%5Btitle%5D=${encoded_title}"
+
+    echo "🔗 Open this URL to create the merge request:"
+    echo "   $mr_url"
+    echo ""
+
+    # Try xdg-open if available
+    if command -v xdg-open &>/dev/null; then
+        echo "Opening in browser..."
+        xdg-open "$mr_url" 2>/dev/null || true
+    fi
+
 # Get snapshot name from merged PR number
 get-snapshot-from-pr app pr_number: (_validate_app app) _check_github_access _check_oc_cluster
     #!/usr/bin/env bash
@@ -1345,9 +1420,14 @@ clone-release-mgmt branch_name:
     # Create branch from main if it doesn't exist, otherwise switch to it
     if git show-ref --verify --quiet refs/heads/{{branch_name}}; then
         git checkout {{branch_name}}
+        git pull origin {{branch_name}} --ff-only 2>/dev/null || true
         echo "✅ Switched to existing branch {{branch_name}}"
+    elif git show-ref --verify --quiet refs/remotes/origin/{{branch_name}}; then
+        git checkout -b {{branch_name}} origin/{{branch_name}}
+        echo "✅ Checked out remote branch {{branch_name}}"
     else
         git checkout -b {{branch_name}} origin/main
+        git push -u origin {{branch_name}}
         echo "✅ Branch {{branch_name}} created from origin/main"
     fi
 
@@ -1377,14 +1457,8 @@ stage-release target app version snapshot rc="" skip_confirm="false" dry_run="tr
         echo "  ✓ Detected OCP versions: ${ocp_versions_resolved}" >&2
     fi
 
-    # Build rc argument if provided
-    rc_arg=""
-    if [ -n "{{rc}}" ]; then
-        rc_arg="--rc {{rc}}"
-    fi
-
     # Ensure workspace exists and correct branch checked out
-    workspace_dir=$(just _ensure_release_mgmt_workspace stage {{app}} {{version}} $rc_arg)
+    workspace_dir=$(just _ensure_release_mgmt_workspace stage {{app}} {{version}})
 
     # Build directory path (stage always goes in rc subdirectory)
     app_upper=$(echo "{{app}}" | tr '[:lower:]' '[:upper:]')
@@ -1435,6 +1509,9 @@ stage-release target app version snapshot rc="" skip_confirm="false" dry_run="tr
         just _apply "$target_yaml" {{skip_confirm}} {{dry_run}}
     fi
 
+    # Push release files incrementally
+    just _push_release_mgmt_files "stage {{target}} {{app}} {{version}} rc{{rc}}"
+
 # Promote stage to prod: copy stage file, update for prod, and apply to cluster
 [arg("rc", long="rc")]
 [arg("skip_confirm", long="skip_confirm")]
@@ -1452,14 +1529,8 @@ prod-release target app version rc="" skip_confirm="false" dry_run="true": (_val
     # Parse version
     read -r major minor patch short_version <<< $(just _parse_version {{version}})
 
-    # Build rc argument if provided
-    rc_arg=""
-    if [ -n "{{rc}}" ]; then
-        rc_arg="--rc {{rc}}"
-    fi
-
     # Ensure workspace exists and correct branch checked out
-    workspace_dir=$(just _ensure_release_mgmt_workspace prod {{app}} {{version}} $rc_arg)
+    workspace_dir=$(just _ensure_release_mgmt_workspace prod {{app}} {{version}})
 
     # Build paths
     app_upper=$(echo "{{app}}" | tr '[:lower:]' '[:upper:]')
@@ -1566,6 +1637,9 @@ prod-release target app version rc="" skip_confirm="false" dry_run="true": (_val
         just _apply "$prod_yaml" {{skip_confirm}} {{dry_run}}
     fi
 
+    # Push release files incrementally
+    just _push_release_mgmt_files "prod {{target}} {{app}} {{version}} (from stage rc{{rc}})"
+
 # Generate snapshot updates: wrapper for bundle or catalog snapshot updates
 [arg("rc", long="rc")]
 [arg("skip_confirm", long="skip_confirm")]
@@ -1604,14 +1678,8 @@ update-bundle-snapshot type app version rc="" skip_confirm="false" dry_run="true
     # Parse version
     read -r major minor patch short_version <<< $(just _parse_version {{version}})
 
-    # Build rc argument if provided
-    rc_arg=""
-    if [ -n "{{rc}}" ]; then
-        rc_arg="--rc {{rc}}"
-    fi
-
     # Ensure workspace exists and correct branch checked out
-    workspace_dir=$(just _ensure_release_mgmt_workspace {{type}} {{app}} {{version}} $rc_arg)
+    workspace_dir=$(just _ensure_release_mgmt_workspace {{type}} {{app}} {{version}})
 
     app_upper=$(echo "{{app}}" | tr '[:lower:]' '[:upper:]')
     release_dir="$workspace_dir/${app_upper}/${app_upper}-{{version}}"
@@ -1790,14 +1858,8 @@ update-catalog-request type app version rc="" skip_confirm="false" dry_run="true
     # Parse version
     read -r major minor patch short_version <<< $(just _parse_version {{version}})
 
-    # Build rc argument if provided
-    rc_arg=""
-    if [ -n "{{rc}}" ]; then
-        rc_arg="--rc {{rc}}"
-    fi
-
     # Ensure workspace exists and correct branch checked out
-    workspace_dir=$(just _ensure_release_mgmt_workspace {{type}} {{app}} {{version}} $rc_arg)
+    workspace_dir=$(just _ensure_release_mgmt_workspace {{type}} {{app}} {{version}})
 
     app_upper=$(echo "{{app}}" | tr '[:lower:]' '[:upper:]')
     release_dir="$workspace_dir/${app_upper}/${app_upper}-{{version}}"
@@ -1814,7 +1876,7 @@ update-catalog-request type app version rc="" skip_confirm="false" dry_run="true
     # Verify bundle snapshot file exists
     if [ ! -f "$bundle_snapshot_file" ]; then
         echo "❌ Bundle snapshot file not found: $bundle_snapshot_file" >&2
-        echo "   Run 'just release bundle {{type}} {{app}} {{version}} <snapshot> $rc_arg' first" >&2
+        echo "   Run 'just release bundle {{type}} {{app}} {{version}} <snapshot> --rc {{rc}}' first" >&2
         exit 1
     fi
 

--- a/konflux/release-process/justfile
+++ b/konflux/release-process/justfile
@@ -106,13 +106,16 @@ help:
     @echo "  just check-pr catalog <PR_NUMBER>"
     @echo "  just check-commit <MERGE_COMMIT_SHA>"
     @echo ""
-    @echo "  # 10. Create catalog release (OCP versions auto-detected)"
-    @echo "  just release catalog stage acm 2.12.42 --snapshot snapshot-def --rc 1 --dry_run false"
+    @echo "  # 10. Get catalog snapshot from merged PR"
+    @echo "  just get-catalog-snapshot stage acm <MERGE_COMMIT_SHA>"
     @echo ""
-    @echo "  # 11. Monitor catalog releases"
+    @echo "  # 11. Create catalog release (OCP versions auto-detected)"
+    @echo "  just release catalog stage acm 2.12.42 --snapshot <CATALOG_SNAPSHOT> --rc 1 --dry_run false"
+    @echo ""
+    @echo "  # 12. Monitor catalog releases"
     @echo "  just check-catalog-releases stage acm 2.12.42 --rc 1"
     @echo ""
-    @echo "  # 12. Create GitLab MR for release files (after all steps done)"
+    @echo "  # 13. Create GitLab MR for release files (after all steps done)"
     @echo "  just create-mr acm 2.12.42"
     @echo ""
     @echo "Prod Release Workflow:"
@@ -207,7 +210,7 @@ query-bugs app version bundle="false": _check_yq
     fi
 
     # Build the JQL query for bugs
-    jql_query="project = \"Red Hat Advanced Cluster Management\" and fixVersion = \"{{app}} {{version}}\" and resolution not in (\"Can't Do\", \"Cannot Reproduce\", Duplicate, MirrorOrphan, \"Not a Bug\", Obsolete, Unresolved, \"Won't Do\") and status not in (open, backlog) and statuscategory in (done) and issuetype NOT IN (Weakness, Vulnerability) and (labels in (doc-required, doc-require, doc-req) OR \"SFDC_Cases_Counter\" > 0)${bundle_clause}"
+    jql_query="project = \"Red Hat Advanced Cluster Management\" and fixVersion = \"{{app}} {{version}}\" and resolution not in (\"Can't Do\", \"Cannot Reproduce\", Duplicate, MirrorOrphan, \"Not a Bug\", Obsolete, Unresolved, \"Won't Do\") and status not in (open, backlog) and statuscategory in (done) and issuetype NOT IN (Vulnerability) and (labels in (doc-required, doc-require, doc-req) OR \"SFDC_Cases_Counter\" > 0)${bundle_clause}"
 
     # Query Jira for bugs
     jira_output=$(jira issue list -q "$jql_query" --raw 2>&1) || {
@@ -1228,24 +1231,24 @@ create-mr app version:
     git log --oneline origin/main..HEAD
     echo ""
 
-    # Build MR URL for push-and-create flow
+    # Empty commit needed for git push -o to trigger MR creation
+    git commit --allow-empty -m "Trigger MR creation"
+
+    # Push and create MR via git push options
     mr_title="${app_upper} {{version}} release files"
-    encoded_title=$(python3 -c "import urllib.parse; print(urllib.parse.quote('${mr_title}'))")
 
-    # Push latest (should be up-to-date from incremental pushes, but ensure)
-    git push origin HEAD
+    push_output=$(git push origin HEAD \
+        -o merge_request.create \
+        -o merge_request.target=main \
+        -o "merge_request.title=${mr_title}" 2>&1)
 
-    # Open MR creation URL
-    mr_url="https://${gitlab_host}/${upstream}/-/merge_requests/new?merge_request%5Bsource_branch%5D=${branch_name}&merge_request%5Btarget_branch%5D=main&merge_request%5Btitle%5D=${encoded_title}"
+    echo "$push_output"
 
-    echo "🔗 Open this URL to create the merge request:"
-    echo "   $mr_url"
-    echo ""
-
-    # Try xdg-open if available
-    if command -v xdg-open &>/dev/null; then
-        echo "Opening in browser..."
-        xdg-open "$mr_url" 2>/dev/null || true
+    # Extract and display MR URL
+    mr_url=$(echo "$push_output" | grep -oP 'https://[^ ]+merge_requests/\d+' | head -1)
+    if [ -n "$mr_url" ]; then
+        echo ""
+        echo "✅ Merge request created: $mr_url"
     fi
 
 # Get snapshot name from merged PR number

--- a/konflux/release-process/utils.just
+++ b/konflux/release-process/utils.just
@@ -379,9 +379,10 @@ _get_ocp_versions app version:
     echo "$ocp_versions_yaml" | sed 's/ocp-//' | tr '\n' ',' | sed 's/,$//'
 
 # Private: ensure acm-release-management is cloned and correct branch checked out
+# Uses a single shared branch per app+version: release-{app}-{version}
+# All stage RCs and prod files go on the same branch.
 # Returns workspace directory path to stdout
-[arg("rc", long="rc")]
-_ensure_release_mgmt_workspace type app version rc="":
+_ensure_release_mgmt_workspace type app version:
     #!/usr/bin/env bash
     set -euo pipefail
 
@@ -391,17 +392,50 @@ _ensure_release_mgmt_workspace type app version rc="":
         exit 0
     fi
 
-    # Parse version to build branch name
-    read -r major minor patch short_version <<< $(just _parse_version {{version}})
-
-    # Build branch name: {type}-release-app-shortversion-zpatch[-rcN]
-    branch_name="{{type}}-release-{{app}}-${short_version}-z${patch}"
-    if [ "{{type}}" = "stage" ] && [ -n "{{rc}}" ]; then
-        branch_name="${branch_name}-rc{{rc}}"
-    fi
+    # Single branch per app+version (shared across stage/prod/all RCs)
+    branch_name="release-{{app}}-{{version}}"
 
     # Clone and checkout branch (clone-release-mgmt handles all the logic)
     just clone-release-mgmt "$branch_name" >&2
 
     # Return workspace path
     echo "acm-release-management"
+
+# Private: commit and push release management files after each step
+# Call after saving files to the release-management repo for incremental backup
+_push_release_mgmt_files commit_msg:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    repo_dir="acm-release-management"
+
+    # Skip if custom workspace
+    if [ "{{workspace}}" != "." ]; then
+        echo "ℹ️  Custom workspace — skipping auto-push" >&2
+        exit 0
+    fi
+
+    if [ ! -d "$repo_dir" ]; then
+        echo "⚠️  Release management repo not found, skipping push" >&2
+        exit 0
+    fi
+
+    cd "$repo_dir"
+
+    # Stage all changes
+    git add -A
+
+    # Check if there are changes to commit
+    if git diff --cached --quiet; then
+        echo "ℹ️  No new changes to push" >&2
+        exit 0
+    fi
+
+    # Build commit message with sign-off
+    full_msg="{{commit_msg}}"
+    full_msg="${full_msg}"$'\n\n'"Signed-off-by: $(git config user.name) <$(git config user.email)>"
+
+    git commit -m "$full_msg"
+    git push origin HEAD
+
+    echo "✅ Pushed release files to remote" >&2


### PR DESCRIPTION
Each step that creates release files now auto-pushes them to a pre-determined branch based on the release name. At the end, a recipe for creating an MR can be run to assist with MR creation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated release workflows: added catalog snapshot retrieval, a mandatory QE pause in prod, multi-app ordering notes, and clarified utilities listing.

* **New Features**
  * Added a command to automate GitLab MR creation.
  * Added automated commit-and-push for release-management changes.
  * Improved branch checkout behavior for release management.

* **Chores**
  * Standardized release-management workspace and branch handling.

* **Bug Fixes**
  * Adjusted issue-query filter to refine results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->