### PR TITLE
Added cve fix for [ext] assisted installer cves

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,6 +3,8 @@ approvers:
 - gparvin
 - xuezhaojun
 - zhujian7
+- cameronmwall
+- dislbenn
 
 reviewers:
 - dhaiducek

--- a/konflux/release-process/justfile
+++ b/konflux/release-process/justfile
@@ -291,7 +291,7 @@ query-cves app version: _check_github_access
         # Exclude Infrastructure Operator component (embargoed assisted-service CVEs)
         map(select(
             (.fields.labels | any(startswith("pscomponent:"))) and
-            (.fields.components | all(.name != "Infrastructure Operator"))
+            (.fields.components | all(.name != "Infrastructure Operator[ext]"))
         )) |
         map({
             key: (.fields.labels[] | select(test("^CVE-[0-9]+-[0-9]+$"))),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated CVE filtering so entries tied to `Infrastructure Operator[ext]` are now excluded correctly.
  * CVE mapping and validation behavior otherwise remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->