### PR TITLE
fix: prevent release management push failures from silent pull errors

### DIFF
--- a/konflux/release-process/justfile
+++ b/konflux/release-process/justfile
@@ -1460,7 +1460,7 @@ clone-release-mgmt branch_name:
     # Create branch from main if it doesn't exist, otherwise switch to it
     if git show-ref --verify --quiet refs/heads/{{branch_name}}; then
         git checkout {{branch_name}}
-        git pull origin {{branch_name}} --ff-only 2>/dev/null || true
+        git pull origin {{branch_name}} --rebase
         echo "✅ Switched to existing branch {{branch_name}}"
     elif git show-ref --verify --quiet refs/remotes/origin/{{branch_name}}; then
         git checkout -b {{branch_name}} origin/{{branch_name}}


### PR DESCRIPTION
- The `clone-release-mgmt` recipe used `git pull --ff-only || true`, which silently swallowed failures when the local release branch had diverged from remote (e.g., after a prior run committed locally but failed to push). This left branches diverged, causing the subsequent `git push` to fail with a non-fast-forward error.
- Switch to `git pull --rebase` without error suppression so local commits are replayed on top of remote, and actual conflicts surface immediately instead of being hidden.

💘 Generated with Crush

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release workflow synchronization when updating an existing local branch.
  * Local changes are now rebased onto the latest remote history for more reliable updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->